### PR TITLE
Fix compiler warning in checksum function

### DIFF
--- a/src/quecGNSS.cpp
+++ b/src/quecGNSS.cpp
@@ -105,7 +105,7 @@ uint8_t quectelGPS::calculateChecksum(uint8_t *pData)
     // While current char isn't '*' or sentence ending (newline)
     while ('*' != *n && NMEA_END_CHAR_1 != *n)
     {
-        if ( ('\0' == *n) || (n - pData > NMEA_MAX_LENGTH) )
+        if ( ('\0' == *n) || ((uint32_t)(n - pData) > NMEA_MAX_LENGTH) )
         {
             // Sentence too long or short
             return 0;


### PR DESCRIPTION
Address issue reported in [Shortcut ](https://app.shortcut.com/particle/story/113557/clear-lint-warning-within-quectelgps-calculatechecksum-for-type-mismatch)ticket. A compiler warning is generated in the checksum function. This pull request is to fix the warning.